### PR TITLE
Fix/filter overwriting

### DIFF
--- a/aempsconn/errors/errors.py
+++ b/aempsconn/errors/errors.py
@@ -67,7 +67,7 @@ class JSONKeyFailure(CustomException):
 
     def __init__(
         self,
-        message: str = "The request you made may be wrong. 'Resultados' should be in the response. You may want to open an issue on 'https://github.com/fqlenos/aempsconn'.",
+        message: str = "The request you made may be wrong. 'Resultados' should be in the response. Check your conditions.",
     ) -> None:
         super().__init__(message)
 
@@ -79,7 +79,7 @@ class JSONDecodeFailure(CustomException):
 
     def __init__(
         self,
-        message: str = "HTTP response seems to be empty. You may want to open an issue on 'https://github.com/fqlenos/aempsconn'.",
+        message: str = "HTTP response seems to be empty. Check your conditions.",
     ) -> None:
         super().__init__(message)
 

--- a/aempsconn/filter/filter.py
+++ b/aempsconn/filter/filter.py
@@ -7,9 +7,10 @@ from ..utils import ConfigModel
 
 
 class Filter:
+    conditions: dict  # just for typing
+
     def __init__(self, config: ConfigModel) -> None:
         self.config: ConfigModel = config
-        self.conditions: dict = {}
 
     def query(self) -> str:
         """
@@ -25,7 +26,7 @@ class Filter:
                     value = 0
 
             query += f"{key}={str(value)}&"
-        query = query[:-1]  # so it removes the last "&"
+        query: str = query[:-1]  # so it removes the last "&"
 
         if self.config.logger is not None:
             self.config.logger.debug(f"Query created: {query}")

--- a/aempsconn/filter/filter_medicamento.py
+++ b/aempsconn/filter/filter_medicamento.py
@@ -17,16 +17,17 @@ class Equals(Generic[T]):
     Adds new condition to the conditions dict
     """
 
+    med: "FilterMedicamento"
+    key: str
+
     def equals(self, value: T) -> "FilterMedicamento":
         """
         "equals" because the condition should be equal to the value added.
         """
-        self.med: FilterMedicamento
-        self.key: str
-        self.med.conditions.clear()  # it clears the dict because only one value is valid.
-        self.med.conditions.update({self.key: value})
+        new_meds = FilterMedicamento(config=self.med.config)
+        new_meds.conditions.update({self.key: value})
 
-        return self.med
+        return new_meds
 
 
 class CodNacionalFilter(Equals[str]):
@@ -61,14 +62,14 @@ class FilterMedicamento(Filter):
         self.conditions: dict = {}
 
     @property
-    def cod_nacional(self):
+    def cod_nacional(self) -> CodNacionalFilter:
         """
         Add condition to "cn"
         """
         return CodNacionalFilter(self)
 
     @property
-    def num_registro(self):
+    def num_registro(self) -> NumRegistroFilter:
         """
         Add condition to "nregistro"
         """

--- a/aempsconn/filter/filter_medicamentos.py
+++ b/aempsconn/filter/filter_medicamentos.py
@@ -284,98 +284,98 @@ class FilterMedicamentos(Filter):
         self.conditions: dict = {}
 
     @property
-    def nombre(self):
+    def nombre(self) -> NombreFilter:
         """
         "Nombre" of the "medicamento".
         """
         return NombreFilter(self)
 
     @property
-    def laboratorio(self):
+    def laboratorio(self) -> LabFilter:
         """
         "Laboratorio" of the "medicamento".
         """
         return LabFilter(self)
 
     @property
-    def pactivo1(self):
+    def pactivo1(self) -> PactivoOneFilter:
         """
         First "principio activo" of the "medicamento".
         """
         return PactivoOneFilter(self)
 
     @property
-    def pactivo2(self):
+    def pactivo2(self) -> PactivoTwoFilter:
         """
         Second "principio activo" of the "medicamento".
         """
         return PactivoTwoFilter(self)
 
     @property
-    def id_pactivo1(self):
+    def id_pactivo1(self) -> IDPactivoOneFilter:
         """
         First ID of the "principio activo" of the "medicamento".
         """
         return IDPactivoOneFilter(self)
 
     @property
-    def id_pactivo2(self):
+    def id_pactivo2(self) -> IDPactivoTwoFilter:
         """
         Second ID of the "principio activo" of the "medicamento".
         """
         return IDPactivoTwoFilter(self)
 
     @property
-    def cod_nacional(self):
+    def cod_nacional(self) -> CodNacionalFilter:
         """
         "Código nacional" of the "medicamento".
         """
         return CodNacionalFilter(self)
 
     @property
-    def atc(self):
+    def atc(self) -> ATCFilter:
         """
         "ATC" of the "medicamento".
         """
         return ATCFilter(self)
 
     @property
-    def num_registro(self):
+    def num_registro(self) -> NumRegistroFilter:
         """
         Add condition to "nregistro"
         """
         return NumRegistroFilter(self)
 
     @property
-    def num_pactivo(self):
+    def num_pactivo(self) -> NumeroPactivoFilter:
         """
         Add condition to "npactiv"
         """
         return NumeroPactivoFilter(self)
 
     @property
-    def triangulo(self):
+    def triangulo(self) -> TrianguloFilter:
         """
         Add condition to "triangulo"
         """
         return TrianguloFilter(self)
 
     @property
-    def huerfano(self):
+    def huerfano(self) -> HuerfanoFilter:
         """
         Add condition to "huerfano"
         """
         return HuerfanoFilter(self)
 
     @property
-    def biosimilar(self):
+    def biosimilar(self) -> BiosimilarFilter:
         """
         Add condition to "biosimilar"
         """
         return BiosimilarFilter(self)
 
     @property
-    def sust(self):
+    def sust(self) -> SustFilter:
         """
         Add condition to "sust", where:
         1: Biológicos,
@@ -387,49 +387,49 @@ class FilterMedicamentos(Filter):
         return SustFilter(self)
 
     @property
-    def vmp(self):
+    def vmp(self) -> VMPFilter:
         """
         Add condition to "vmp"
         """
         return VMPFilter(self)
 
     @property
-    def comercializado(self):
+    def comercializado(self) -> ComercFilter:
         """
         Add condition to "comerc"
         """
         return ComercFilter(self)
 
     @property
-    def autorizado(self):
+    def autorizado(self) -> AutorizadosFilter:
         """
         Add condition to "autorizados"
         """
         return AutorizadosFilter(self)
 
     @property
-    def receta(self):
+    def receta(self) -> RecetaFilter:
         """
         Add condition to "receta"
         """
         return RecetaFilter(self)
 
     @property
-    def estupefaciente(self):
+    def estupefaciente(self) -> EstupefacienteFilter:
         """
         Add condition to "estupefaciente"
         """
         return EstupefacienteFilter(self)
 
     @property
-    def psicotropo(self):
+    def psicotropo(self) -> PsicotropoFilter:
         """
         Add condition to "psicotropo"
         """
         return PsicotropoFilter(self)
 
     @property
-    def estupsico(self):
+    def estupsico(self) -> EstuopsicoFilter:
         """
         Add condition to "estupsico"
         """

--- a/aempsconn/modules/cima/medicamentos.py
+++ b/aempsconn/modules/cima/medicamentos.py
@@ -25,7 +25,7 @@ class Medicamentos(Base):
         return Endpoint.MEDICAMENTOS.value
 
     @json_res_handler
-    def get(self, filter: FilterMedicamentos) -> list[ListMedicamentoModel] | None:
+    def get(self, filter: FilterMedicamentos) -> list[ListMedicamentoModel]:
         """
         Create specific response with the cororect data type
 
@@ -46,7 +46,8 @@ class Medicamentos(Base):
         if len(results) > 0:
             for medicamento in results:
                 medicamentos.append(ListMedicamentoModel(**medicamento))
-            return medicamentos
 
-        if self.config.logger is not None:
+        if self.config.logger is not None and not medicamentos:
             self.config.logger.info("The respose seems to be empty.")
+
+        return medicamentos

--- a/aempsconn/orchestrate/orchestrate.py
+++ b/aempsconn/orchestrate/orchestrate.py
@@ -45,7 +45,6 @@ class Orchestrate:
 
         # Initialize existing modules with current configuration.
         Base(config=config)
-        Filter(config=config)
 
         # Related to CIMA
         self.filter_medicamento = FilterMedicamento(config=config)


### PR DESCRIPTION
**Correction of two small bugs** 

1. When trying to use a list of filters (`aempsconn.filter_medicamento`) the previous filter is overwritten.
2. When trying to use a list of filters (`aempsconn.filter_medicamentos`) the previous filter is overwritten.